### PR TITLE
Change GithubEventBot to not use DiscordUtils#sendRemovableEmbed, so …

### DIFF
--- a/src/main/java/io/horrorshow/codey/api/github/GithubEventBot.java
+++ b/src/main/java/io/horrorshow/codey/api/github/GithubEventBot.java
@@ -49,8 +49,8 @@ public class GithubEventBot {
                         .map(channelInfo -> {
                             var channel = channelInfo.channel();
                             var textChannel = channel.getJDA().getTextChannelById(channel.getId());
-                            if (textChannel != null) {
-                                return DiscordUtils.sendRemovableEmbed(embed, textChannel);
+                            if(textChannel!= null){
+                                return CompletableFuture.completedFuture(textChannel.sendMessage(embed).complete());
                             }
                             return null;
                         }).toArray(CompletableFuture[]::new)

--- a/src/main/java/io/horrorshow/codey/discordutil/ApplicationState.java
+++ b/src/main/java/io/horrorshow/codey/discordutil/ApplicationState.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,14 +42,14 @@ public class ApplicationState {
      *
      * The fact that the hashmap is empty on restart does not matter too much.
      */
-    private final Map<String,Boolean> deleteableMessageIds;
+    private final ConcurrentHashMap<String,Boolean> deleteableMessageIds;
 
 
     @Autowired
     public ApplicationState(JDA jda, Repositories repositories) {
         this.githubEventState = new GithubEventState(jda, repositories.getGithubChannelRepository());
         this.elevatedUsersState = new ElevatedUsersState(repositories.getElevatedUserRepository());
-        this.deleteableMessageIds = new HashMap<>();
+        this.deleteableMessageIds = new ConcurrentHashMap<>();
     }
 
 

--- a/src/main/java/io/horrorshow/codey/discordutil/CommonJDAListener.java
+++ b/src/main/java/io/horrorshow/codey/discordutil/CommonJDAListener.java
@@ -8,6 +8,8 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 
@@ -22,6 +24,8 @@ public class CommonJDAListener extends ListenerAdapter {
         jda.addEventListener(this);
     }
 
+    //Being static avoids the need to inject this map to DiscordUtils
+    public static Map<String,Boolean> deletableMessageMap = new HashMap<>();
 
     @Override
     public void onGuildMessageReactionAdd(@NotNull GuildMessageReactionAddEvent event) {
@@ -33,9 +37,19 @@ public class CommonJDAListener extends ListenerAdapter {
 
     public void onReactionAdd(@NotNull GuildMessageReactionAddEvent event) {
         var message = event.getChannel().retrieveMessageById(event.getMessageId()).complete();
+        /***
+         * Use a hashmap that is not persisted in any way to look up if the message should be deletable.
+         *
+         * It should not be a big issue, if a user reacts, and the message is not deleted.
+         * However, vice-versa is not true. If a malicious user reacts, and the message is deleted - that is an issue.
+         *
+         * The fact that the hashmap is empty on restart does not matter too much.
+         */
+
         if (DiscordUtils.hasEmoji(BASKET, event)) {
-            if (event.getJDA().getSelfUser().getId().equals(message.getAuthor().getId())) {
+            if (deletableMessageMap.containsKey(event.getMessageId()) && event.getJDA().getSelfUser().getId().equals(message.getAuthor().getId())) {
                 try {
+                    deletableMessageMap.remove(message.getId());
                     message.delete().complete();
                 } catch (ErrorResponseException e) {
                     log.warn("Unable to remove message");

--- a/src/main/java/io/horrorshow/codey/discordutil/DiscordUtils.java
+++ b/src/main/java/io/horrorshow/codey/discordutil/DiscordUtils.java
@@ -37,6 +37,7 @@ public class DiscordUtils {
 
     public static CompletableFuture<Message> sendRemovableMessageAsync(String text, TextChannel channel) {
         var message = channel.sendMessage(text).complete();
+        CommonJDAListener.deletableMessageMap.put(message.getId(), true);
         message.addReaction(BASKET).queue();
         return CompletableFuture.completedFuture(message);
     }
@@ -44,6 +45,7 @@ public class DiscordUtils {
 
     public static CompletableFuture<Message> sendRemovableEmbed(MessageEmbed embed, TextChannel channel) {
         var message = channel.sendMessage(embed).complete();
+        CommonJDAListener.deletableMessageMap.put(message.getId(), true);
         message.addReaction(BASKET).complete();
         return CompletableFuture.completedFuture(message);
     }
@@ -58,6 +60,7 @@ public class DiscordUtils {
 
     public static void sendRemovableMessage(String text, TextChannel channel) {
         var message = channel.sendMessage(text).complete();
+        CommonJDAListener.deletableMessageMap.put(message.getId(), true);
         message.addReaction(BASKET).complete();
     }
 
@@ -109,6 +112,7 @@ public class DiscordUtils {
 
     public static CompletableFuture<Message> sendRemovableMessageReply(Message origin, MessageEmbed content) {
         var message = origin.reply(content).complete();
+        CommonJDAListener.deletableMessageMap.put(message.getId(), true);
         message.addReaction(BASKET).queue();
         return CompletableFuture.completedFuture(message);
     }


### PR DESCRIPTION
…that the messages cannot be deleted via react.

This is in response to modestai's message in #off-topic in the discord:

> @Phil can i delete codey messages from community-commits
> I mean i think you should make it to restrictive access only

Pretty sure that's exactly what this does - instead of sending the message via discord utils that will queue up a waste-backet emoji, TextChannel#sendMessage is used.